### PR TITLE
Mark 0template 0.6 as stable

### DIFF
--- a/tools/0template.xml
+++ b/tools/0template.xml
@@ -73,7 +73,7 @@
       <manifest-digest sha256new="PN4O6HVQQ4YV7SBXFOKGJ6T3BSCJ33VTWYZAXZKDO7LD36TCTUNQ"/>
       <archive extract="0template-0.5" href="0template-0.5.tar.bz2" size="17556"/>
     </implementation>
-    <implementation id="sha1new=03a80899236770b139c3c4be1d2255e4644a1a32" license="OSI Approved :: GNU Lesser General Public License (LGPL)" released="2018-11-17" version="0.6">
+    <implementation id="sha1new=03a80899236770b139c3c4be1d2255e4644a1a32" license="OSI Approved :: GNU Lesser General Public License (LGPL)" released="2018-11-17" stability="stable" version="0.6">
       <manifest-digest sha256new="GHJMUQA4THAAAG62R4R55U2CLFGHNVIRH2TTBLKYH4SKBMZF7JPQ"/>
       <archive extract="0template-0.6" href="0template-0.6.tar.bz2" size="17585"/>
     </implementation>


### PR DESCRIPTION
0template 0.5 had a bug (downloading archives was broken, fixed in 0install/0template@b867667413d9b5608ca7c22e8be92c789dfad55f) so 0.6 should be the default version users get.